### PR TITLE
fix: use correct experiment import for cocoapods

### DIFF
--- a/Sources/AmplitudeUnified/ObjCAmplitude+Unified.swift
+++ b/Sources/AmplitudeUnified/ObjCAmplitude+Unified.swift
@@ -6,7 +6,12 @@
 //
 
 import Foundation
-import Experiment
+
+#if canImport(AmplitudeExperiment)
+@_exported import AmplitudeExperiment
+#else
+@_exported import Experiment
+#endif
 
 #if canImport(AmplitudeSessionReplay)
 import AmplitudeSessionReplay


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

experiment imported from cocoapods uses a different module name

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
