### PR TITLE
fix: New log level types compatibility

### DIFF
--- a/Sources/AmplitudeUnified/ObjCAnalyticsConfig.swift
+++ b/Sources/AmplitudeUnified/ObjCAnalyticsConfig.swift
@@ -51,7 +51,7 @@ extension ObjCConfiguration {
         if let logger {
             loggerProvider = logger
         }
-        logLevel = analyticsConfig.logLevel
+        logLevel = ObjCLogLevel(analyticsConfig.logLevel)
         minIdLength = analyticsConfig.minIDLength
         callback = analyticsConfig.callback
         partnerId = analyticsConfig.partnerID


### PR DESCRIPTION
### Summary

It fixes a compile time issue which exists since [v1.17.0](https://github.com/amplitude/Amplitude-Swift/releases/tag/v1.17.0) of Amplitude-Swift. It changed the type of log levels, and thus introduced incompatibility within unified SDK.

Currently the only workaround was to manually specify the version of Amplitude-Swift to use

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  NO
