### PR TITLE
fix: use correct default for ObjC logLevel

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,6 @@ jobs:
           - runs-on: macos-15
             platform: macOS
             xcode: 16.4
-            test-destination-os: latest
 
           - runs-on: macos-15
             platform: tvOS
@@ -75,7 +74,7 @@ jobs:
               xcodebuild test \
                 -scheme AmplitudeUnified \
                 -sdk macosx \
-                -destination 'platform=macOS,OS=${{ matrix.test-destination-os }}'
+                -destination 'platform=macOS'
               ;;
             tvOS)
               xcodebuild \

--- a/Sources/AmplitudeUnified/ObjCAnalyticsConfig.swift
+++ b/Sources/AmplitudeUnified/ObjCAnalyticsConfig.swift
@@ -15,7 +15,7 @@ public class ObjCAnalyticsConfig: NSObject {
 
     public var flushQueueSize = Configuration.Defaults.flushQueueSize
     public var flushIntervalMillis = Configuration.Defaults.flushIntervalMillis
-    public var logLevel = Configuration.Defaults.logLevel
+    public var logLevel = ObjCLogLevel.WARN
     public var minIDLength = -1
     public var partnerID: String?
     public var callback: ObjCEventCallback?


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

ObjC config should use ObjC log level

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no